### PR TITLE
Replace Yomichan with Yomitan (the latest fork)

### DIFF
--- a/docs/ankicards.md
+++ b/docs/ankicards.md
@@ -164,7 +164,7 @@ Some words will only appear in certain expressions. As this context will be iden
 will see the word, it is fine to include it as a hint.
 
 As for the reason why you wouldn't mine the entire expression in the first place: they might not have entries in
-Japanese to Japanese dictionaries and may not be voiced in the Yomichan audio.
+Japanese to Japanese dictionaries and may not be voiced in the Yomitan audio.
 
 <figure>
   <img src="/images/expressions.jpg"/>

--- a/docs/ankisetup.md
+++ b/docs/ankisetup.md
@@ -159,7 +159,7 @@ The other solutions are outdated. Use Straight Rewards.
 ### [Yomichan Forvo Server](https://ankiweb.net/shared/info/580654285)
 
 A plugin that makes getting audio from Forvo into Anki incredibly simple. Using this there will be almost no unvoiced
-words in your deck when you mine with Yomichan and if you do find unvoiced things you can add them to Forvo yourself.
+words in your deck when you mine with Yomitan/Yomichan and if you do find unvoiced things you can add them to Forvo yourself.
 
 ---
 
@@ -205,9 +205,11 @@ rather than the 'again count'.
 
 ---
 
-### [Kanji Grid](https://ankiweb.net/shared/info/909972618)
+### [Kanji Grid Kuuube](https://ankiweb.net/shared/info/1610304449)
 
-Want to know how many kanji you know? This addons scans your cards for kanji and displays them in a nice looking grid.
+[comment]: <> (This version of Kanji Grid is compatible with the newer Anki versions unlike the original and adds more functionality to it. We should probably replace the picture but I do not have the animecards anki deck setup like in the picture.)
+
+Want to know how many kanji you know? This addon scans your cards for kanji and displays them in a nice looking grid.
 Also has several sorting options such as school grades or JLPT. Be sure to limit the options to the deck and the field
 that you are actually learning from or results might be skewed.
 

--- a/docs/learningjapanese.md
+++ b/docs/learningjapanese.md
@@ -134,7 +134,7 @@ between looking things up and ignoring them, so you do end up learning a fair am
 frustrated having to look something up every line.
 
 My personal recommendation for easy content at this stage is anime with Japanese subtitles. See
-the [Yomichan](yomichansetup.md) and [anime section](ankisetup.md) on ways to easily look things up and possibly mine.
+the [Yomitan](yomichansetup.md) and [anime section](ankisetup.md) on ways to easily look things up and possibly mine.
 
 <figure>
   <img src="/images/tv_boy_tooku.png" width="300">

--- a/docs/minefromanime.md
+++ b/docs/minefromanime.md
@@ -25,7 +25,7 @@ video demonstration:
 
 ### Requirements
 
-1. A [mining deck set up with Yomichan](yomichansetup.md) (you can find a template deck you can
+1. A [mining deck set up with Yomitan](yomichansetup.md) (you can find a template deck you can
    use [here](https://ankiweb.net/shared/info/151553357)).
 2. The mpv player. <p>mpv ([get it here if you are on Windows](https://mpv.io/)) is a free video player with great scripting capabilities.</p>
 3. The script itself. The newest version can always be found
@@ -36,7 +36,7 @@ video demonstration:
    or [Firefox](https://addons.mozilla.org/ja/firefox/addon/clipboard-inserter/)) (also useful for visual novels).
 5. **(Linux users only)** Make sure xclip and curl are installed.
 
-Ensure Yomichan (and the clipboard plugin too) have access to file URLs otherwise Yomichan can't capture text from the
+Ensure Yomitan (and the clipboard plugin too) have access to file URLs otherwise Yomitan can't capture text from the
 text hooking page.
 <figure>
   <img src="/images/yomichanaccess.jpg"/>
@@ -89,12 +89,12 @@ would set `local AUTOPLAY_AUDIO = true` but that is mere preference.
    html page linked above (or <a href="/assets/hZ4sawL4.html" download>here</a>) as other pages may add symbols that
    break the script on certain browsers.</p>
 2. Open your anime with mpv and Japanese subtitle. <p>The subtitles will appear on the html page and you can scan them
-   with Yomichan.
+   with Yomitan.
    <video controls>
     <source src="/video/clipboardmpv.mp4" type="video/mp4">
     Your browser does not support the video tag.
     </video>
-3. When there is a word you want to mine, [create a card with Yomichan](yomichansetup.md).
+3. When there is a word you want to mine, [create a card with Yomitan](yomichansetup.md).
 4. Select the entire sentence/section you want to have as context on your card and copy it.
 5. Go back into the mpv window and press Ctrl + v <p>A notification should appear saying that the card got updated. The
    card should now be updated.
@@ -127,7 +127,7 @@ ngen update
 ## Animebook
 
 [Animebook](https://github.com/animebook/animebook.github.io) is a web video player that displays subtitles next to the
-video played. The advantage is that you can look up the subtitles directly on the video with Yomichan and that they are
+video played. The advantage is that you can look up the subtitles directly on the video with Yomitan and that they are
 displayed next to the video so you don't have to alt tab, but less video formats are supported (although this shouldn't
 be a problem if you are using a Chromium build with extended codecs).
 
@@ -137,7 +137,7 @@ be a problem if you are using a Chromium build with extended codecs).
 
 - For a full overview of video compatibility see
   here: <https://github.com/animebook/animebook.github.io#video-format-support>
-- If you don't have Yomichan setup yet with a mined card format see the [Yomichan setup section](yomichansetup.md).
+- If you don't have Yomitan setup yet with a mined card format see the [Yomitan setup section](yomichansetup.md).
 
 ---
 
@@ -149,7 +149,7 @@ the [extension page](https://chrome.google.com/webstore/detail/animebook-anki-ex
 
 ### Usage without Animebook extension
 
-1. Mine a word using Yomichan
+1. Mine a word using Yomitan
 2. Copy the sentence and paste it into the sentence field
 3. Use the sidebar and click on where you would like to start capturing the audio from
 4. Record the audio using ShareX (or equivalent) and paste it into the audio field

--- a/docs/visualnovels.md
+++ b/docs/visualnovels.md
@@ -2,11 +2,11 @@
 
 Visual novels are possibly the best resource to learn from. The combination of written Japanese and voiced text and
 dialogue makes them a good resource both for beginners and advanced learners and most importantly, they are fun. In this
-section I will show you how to extract the text from a visual novel and use Yomichan and ShareX to 'mine' them.
+section I will show you how to extract the text from a visual novel and use Yomitan and ShareX to 'mine' them.
 
 - If you don't have tools set up to capture audio and screenshots yet take a look at
   the [Handling Media section](media.md).
-- If you don't have a mined deck set up with Yomichan yet see the [Yomichan setup page](yomichansetup.md)
+- If you don't have a mined deck set up with Yomitan yet see the [Yomitan setup page](yomichansetup.md)
 
 ---
 
@@ -33,7 +33,7 @@ time). There are cases where it is useful however. Basic usage of it is detailed
 
 ## HTML Page and Clipboard inserter
 
-To make use of the extracted text to do lookups and create flashcards with Yomichan we utilize an empty html page with a
+To make use of the extracted text to do lookups and create flashcards with Yomitan we utilize an empty html page with a
 plugin that pastes our clipboard into it.
 
 Get the plugin here:
@@ -74,7 +74,7 @@ into Anki and it appears in the html page!
 
 You can now mine from visual novels:
 
-1. Identify a word you want to mine and create a card with Yomichan
+1. Identify a word you want to mine and create a card with Yomitan
 2. Paste the text that is inside your clipboard into Anki
 3. Record the audio and paste it into the audio field
 4. Take a screenshot and paste it into the picture field
@@ -205,8 +205,8 @@ modes to find what best works for you. I recommend `View -> Full-screen mode`. T
 this up once for every VN! Once you close the VN simply tick `Save machine state` and you will be right back when you
 were next time you launch the VM.
 
-Reading the VN and utilizing Textractor on the VM, you can Yomichan scan in the hooking window on your host machine and
-mine unknown words with Yomichan to Anki. Enjoy!
+Reading the VN and utilizing Textractor on the VM, you can Yomitan scan in the hooking window on your host machine and
+mine unknown words with Yomitan to Anki. Enjoy!
 
 ## Reading visual novels on Linux | Alternatives
 

--- a/docs/yomichansetup.md
+++ b/docs/yomichansetup.md
@@ -1,8 +1,10 @@
-# Setting up Yomichan
+# Setting up Yomichan/Yomitan
 
-Yomichan is a web browser extension with a pop-up dictionary function that also lets you create Anki flashcards.
+**Disclaimer: [Yomichan](https://foosoft.net/projects/yomichan/) is no longer maintained. A new fork called [Yomitan](https://github.com/themoeway/yomitan) has emerged to fix most of the bugs Yomichan still had and to enable the Manifest V3 transition that will make Yomichan unusable on Chrome. Moving forward, it is recommended to switch over to Yomitan.**
+
+Yomitan is a web browser extension with a pop-up dictionary function that also lets you create Anki flashcards.
 Creating your own flashcards using Japanese content you are consuming is what people refer to as 'mining'. The
-remarkable thing about Yomichan is the amount of customizability it offers as well as the support for a variety of
+remarkable thing about Yomitan is the amount of customizability it offers as well as the support for a variety of
 Japanese dictionary.
 
 If you haven't done, so already you should verify you are using
@@ -14,11 +16,11 @@ a [Japanese font and not a Chinese one](https://learnjapanese.moe/font/).
 
 ---
 
-## Install Yomichan
+## Install Yomitan
 
-Chrome: <https://chrome.google.com/webstore/detail/yomichan/ogmnaimimemjmbakcfefmnahgdfhfami>
+Chrome: <https://chromewebstore.google.com/detail/likgccmbimhjbgkjambclfkhldnlhbnn>
 
-Firefox: <https://addons.mozilla.org/en-US/firefox/addon/yomichan/>
+Firefox: <https://addons.mozilla.org/en-US/firefox/addon/yomitan/>
 
 After reading the usage guide and getting familiar with basic functionality you can deactivate the 'Show usage guide on
 startup'.
@@ -29,15 +31,15 @@ startup'.
 
 AnkiConnect: <https://ankiweb.net/shared/info/2055492159>
 
-In order to let Yomichan interact with Anki you need the AnkiConnect plugin.
+In order to let Yomitan interact with Anki you need the AnkiConnect plugin.
 
 Tools → Add-ons → Get Add-ons → Code: 2055492159 → OK → Restart Anki after installation
 
 ---
 
-## Install dictionaries for Yomichan
+## Install dictionaries for Yomitan
 
-Yomichan supports a number of different dictionaries a couple of which you can
+Yomitan supports a number of different dictionaries a couple of which you can
 find [here](https://foosoft.net/projects/yomichan/index.html#dictionaries). I recommend you start by installing the
 following:
 
@@ -47,11 +49,11 @@ following:
 
 <figure>
   <img src="/images/installdictionary.gif" width="300"/>
-  <figcaption>Importing a dictionary into Yomichan.</figcaption>
+  <figcaption>Importing a dictionary into Yomichan/Yomitan.</figcaption>
 </figure>
 
 If you want to import your own dictionaries you can
-use [Yomichan Import](https://foosoft.net/projects/yomichan-import/). This tool makes it easy to get an updated version
+use [Yomitan Import](https://github.com/themoeway/yomitan-import). This tool makes it easy to get an updated version
 of JMdict for example.
 
 ---
@@ -110,7 +112,7 @@ The final popup might look something like this:
 
 <figure>
   <img src="/images/yomichanentry.jpg" width="500"/>
-  <figcaption>Yomichan scan.</figcaption>
+  <figcaption>Yomitan scan.</figcaption>
 </figure>
 
 ---
@@ -118,14 +120,14 @@ The final popup might look something like this:
 ## Additional settings
 
 You should change the `Maximum number of child popups` to something other than zero. This enables you scan
-words inside the Yomichan popup. Very useful when combined with J-J dictionaries. You have to tick 
+words inside the Yomitan popup. Very useful when combined with J-J dictionaries. You have to tick 
 `Allow scanning popup content` first to see this option.
 
 ![Additional results in Yomichan](images/additionalresults.jpg)
 
 ---
 
-## Connect Yomichan and Anki
+## Connect Yomitan and Anki
 
 Tick 'Enable Anki integration'.
 
@@ -145,13 +147,13 @@ Handlebars no longer have to be edited with the new card format.
 
 ### Card Configuration
 
-See [GitHub page](https://github.com/friedrich-de/Basic-Mining-Deck) for the recommended Yomichan fields/templates.
+See [GitHub page](https://github.com/friedrich-de/Basic-Mining-Deck) for the recommended Yomichan/Yomitan fields/templates.
 
 ---
 
 ## Result
 
-You can now very easily create basic word cards by hovering over a word with Yomichan and pressing the + button. If
+You can now very easily create basic word cards by hovering over a word with Yomitan and pressing the + button. If
 pitch accent information is available it will also be present.
 
 


### PR DESCRIPTION
This commit changes the setup from Yomichan to [Yomitan](https://github.com/themoeway/yomitan), the best fork I know of for Yomichan right now. 

Wherever the text or the pictures referred to Yomichan directly, I either kept the Yomichan reference or I changed it to Yomitan/Yomichan. This notably fixes the fact you cannot download Yomichan from FooSoft directly anymore (and the myriad of bugs with it), and it makes sure the basic setup is correct. 
I also changed the reference to Kanji Grid because the version linked doesn't work anymore.

PS: I link animecards on [my website](https://donkuri.github.io/learn-japanese/resources/#japanese-learning-guides) so I thought I'd help make sure the critical stuff at least is up to date. Let me know if you're interested in a bit more help.